### PR TITLE
fix: handle missing drive_state in vehicle data

### DIFF
--- a/teslajsonpy/controller.py
+++ b/teslajsonpy/controller.py
@@ -660,19 +660,22 @@ class Controller:
                     response = None
 
                 if response:
+                    drive_state = response.get("drive_state") or {}
+                    shift_state = drive_state.get("shift_state")
                     if (
                         self.cars[vin].is_climate_on
-                        and self.cars[vin].is_climate_on
-                        != response["drive_state"]["shift_state"]
-                        and (
-                            response["drive_state"]["shift_state"] is None
-                            or response["drive_state"]["shift_state"] == "P"
-                        )
+                        and self.cars[vin].is_climate_on != shift_state
+                        and (shift_state is None or shift_state == "P")
                     ):
+                        drive_state_timestamp = drive_state.get("timestamp")
                         self.set_last_park_time(
                             vin=vin,
-                            timestamp=response["drive_state"]["timestamp"] / 1000,
-                            shift_state=response["drive_state"]["shift_state"],
+                            timestamp=(
+                                time.time()
+                                if drive_state_timestamp is None
+                                else drive_state_timestamp / 1000
+                            ),
+                            shift_state=shift_state,
                         )
                     self._last_update_time[vin] = round(time.time())
 

--- a/tests/unit_tests/test_update.py
+++ b/tests/unit_tests/test_update.py
@@ -1,0 +1,37 @@
+"""Test controller updates."""
+
+import copy
+import time
+
+import pytest
+
+from teslajsonpy.controller import Controller
+
+from tests.tesla_mock import CAR_ID, TeslaMock, VIN
+
+
+@pytest.mark.asyncio
+async def test_update_handles_vehicle_data_without_drive_state(monkeypatch):
+    """Test update handles vehicle data payloads missing drive_state."""
+    original_update = Controller.update
+    mock = TeslaMock(monkeypatch)
+    monkeypatch.setattr(Controller, "update", original_update)
+
+    controller = Controller(None)
+    await controller.connect()
+    await controller.generate_car_objects()
+
+    cached_data = controller.cars[VIN]._vehicle_data
+    cached_data["climate_state"]["is_climate_on"] = True
+
+    mock._vehicle_data = copy.deepcopy(cached_data)
+    mock._vehicle_data["charge_state"]["battery_level"] = 55
+    mock._vehicle_data.pop("drive_state")
+
+    before_update = int(time.time())
+
+    await controller.update(car_id=CAR_ID, force=True)
+
+    assert controller.get_last_update_time(vin=VIN) >= before_update
+    assert controller.get_last_park_time(vin=VIN) >= before_update
+    assert controller.cars[VIN].battery_level == 55


### PR DESCRIPTION
## Summary
- Guard vehicle data refreshes when the response omits `drive_state`
- Preserve updates for the rest of the vehicle payload instead of raising `KeyError`
- Add a regression test for missing `drive_state` during `Controller.update`

## Testing
- `uv run --with . --with pytest --with pytest-asyncio python -m pytest tests/unit_tests/test_update.py -q`

Fixes alandtse/tesla#1188